### PR TITLE
chore: remove dead code and duplication

### DIFF
--- a/backend/common/setup_logging.py
+++ b/backend/common/setup_logging.py
@@ -1,9 +1,0 @@
-import logging
-
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-    datefmt="%Y-%m-%d %H:%M:%S",
-)
-
-logger = logging.getLogger(__name__)

--- a/backend/common/utils.py
+++ b/backend/common/utils.py
@@ -1,6 +1,24 @@
 import os
 from jinja2 import Environment, FileSystemLoader
 
+from common.api_types import HealthData
+
+
+def build_human_metrics(data: HealthData) -> str:
+    """Format a HealthData record into the metrics string used by recommender prompts."""
+    goals = data.goals or "None"
+    body_fat = (
+        f"{data.body_fat_percentage}%"
+        if data.body_fat_percentage is not None
+        else "Not provided"
+    )
+    return (
+        f"Age: {data.age}, Weight: {data.weight}kg, Height: {data.height}cm, "
+        f"Fitness Level: {data.fitness_level}, Gender: {data.gender}, "
+        f"Occupation: {data.occupation}, Average Sleep: {data.average_sleep_hours} hours, "
+        f"Body Fat: {body_fat}, Goals: {goals}"
+    )
+
 
 def render_template(template_path: str, **context) -> str:
     """

--- a/backend/models/bodyfat_model.py
+++ b/backend/models/bodyfat_model.py
@@ -93,7 +93,6 @@ class BodyFatModel(AbstractModel):
 
 
 if __name__ == "__main__":
-    # ponytail: one self-check per formula against a known-good reference value.
     # If the coefficients drift, these asserts fail. Run: python -m models.bodyfat_model
     from common.api_types import BodyFatInput
 

--- a/backend/models/diet_model.py
+++ b/backend/models/diet_model.py
@@ -1,7 +1,7 @@
 from common.api_types import HealthData
 from common.config import config
 from common.client import client
-from common.utils import render_template
+from common.utils import render_template, build_human_metrics
 
 from models.abstract_model import AbstractModel
 
@@ -22,19 +22,7 @@ class DietModel(AbstractModel):
         Returns:
             str: AI-generated recommendation string.
         """
-        # Construct human metrics string
-        goals: str | None = data.goals or "None"
-        body_fat = (
-            f"{data.body_fat_percentage}%"
-            if data.body_fat_percentage is not None
-            else "Not provided"
-        )
-        human_metrics = (
-            f"Age: {data.age}, Weight: {data.weight}kg, Height: {data.height}cm, "
-            f"Fitness Level: {data.fitness_level}, Gender: {data.gender}, "
-            f"Occupation: {data.occupation}, Average Sleep: {data.average_sleep_hours} hours, "
-            f"Body Fat: {body_fat}, Goals: {goals}"
-        )
+        human_metrics = build_human_metrics(data)
 
         # Render template using the general utility function
         # Provide the relative path to the template for loading from the prompts directory

--- a/backend/models/workout_model.py
+++ b/backend/models/workout_model.py
@@ -1,7 +1,7 @@
 from common.api_types import HealthData
 from common.config import config
 from common.client import client
-from common.utils import render_template
+from common.utils import render_template, build_human_metrics
 
 from models.abstract_model import AbstractModel
 
@@ -22,19 +22,7 @@ class WorkoutModel(AbstractModel):
         Returns:
             str: AI-generated recommendation string.
         """
-        # Construct human metrics string
-        goals: str | None = data.goals or "None"
-        body_fat = (
-            f"{data.body_fat_percentage}%"
-            if data.body_fat_percentage is not None
-            else "Not provided"
-        )
-        human_metrics = (
-            f"Age: {data.age}, Weight: {data.weight}kg, Height: {data.height}cm, "
-            f"Fitness Level: {data.fitness_level}, Gender: {data.gender}, "
-            f"Occupation: {data.occupation}, Average Sleep: {data.average_sleep_hours} hours, "
-            f"Body Fat: {body_fat}, Goals: {goals}"
-        )
+        human_metrics = build_human_metrics(data)
 
         # Render template using the general utility function
         # Provide the relative path to the template for loading from the prompts directory

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -94,7 +94,7 @@ const buildComponents = (p: {
       contained: {
         backgroundColor: p.ink,
         color: p.onInk,
-        // ponytail: #2A2D31 is a hand-derived darken of ink (#15171A); lift to a token if more hover states need it.
+        // #2A2D31 is a hand-derived darken of ink (#15171A); lift to a token if more hover states need it.
         '&:hover': { backgroundColor: p.isDark ? '#000000' : '#2A2D31' },
         '&.Mui-disabled': { backgroundColor: p.rule, color: p.muted },
       },
@@ -129,7 +129,7 @@ const buildComponents = (p: {
       root: { borderRadius: '2px', fontWeight: 600, fontFamily: FONT_MONO, fontSize: '0.75rem' },
     },
   },
-  // ponytail: severity (success/warning/error) colors are intentionally neutralized —
+  // severity (success/warning/error) colors are intentionally neutralized —
   // status uses the signal-orange token globally, never MUI's default green/red.
   MuiAlert: {
     styleOverrides: { root: { borderRadius: '2px', fontSize: '0.875rem', border: `1px solid ${p.rule}` } },


### PR DESCRIPTION
## Summary

Backend cleanup — no behavior change. Verified with ruff + import smoke test.

- **Delete `backend/common/setup_logging.py`** — dead module; nothing imports it (not `main.py`, no router/service/model, not the `uv run fastapi dev` startup which configures its own logging).
- **Extract `build_human_metrics()` into `common/utils.py`** — `DietModel` and `WorkoutModel` each carried a verbatim 13-line copy of the `human_metrics` construction. Now both call one helper; the two models differ only by class name and template path.
- **Drop `ponytail:` process comments** from `frontend/src/theme.ts` and `backend/models/bodyfat_model.py`, keeping the useful technical notes (hand-derived color explanation, severity-color rationale, runnable self-check hint).

Net: 1 file deleted, ~26 lines of duplication removed.

## Checklist
- [x] ruff check passes
- [x] app + both refactored models import cleanly
- [x] no references to deleted module remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)